### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "laravel/framework": "^10.0|^11.0|^12.0",
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
     "laravel/pennant": "^1.0",
     "markrogoyski/math-php": "^2.0"
   },


### PR DESCRIPTION
## Summary
- Widens `laravel/framework` constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- No runtime code changes were required (the package only depends on `laravel/pennant` and `markrogoyski/math-php`, both of which already support L13)

## Test plan
- [x] Verified in a downstream Laravel 13.9 project: composer resolves cleanly, full app test suite (201 tests) passes